### PR TITLE
Add article provider

### DIFF
--- a/app/services/article_provider.rb
+++ b/app/services/article_provider.rb
@@ -1,0 +1,76 @@
+# Public: ArticleProvider creates a Article object from a markdown file
+class ArticleProvider
+
+  # Public: Initialize the ArticleProvider class
+  #
+  # filename - The filename for creating a new Article object
+  #
+  # Examples
+  #
+  #   ArticleProvider.new "/path/to/markdown/fil.md"
+  def initialize(filename)
+    @filename = filename
+  end
+
+  # Public: Creates the Article from a given filename
+  #
+  # Returns a new Article object
+  def execute
+    begin
+      markdown = File.read(@filename)
+      parser = MarkdownParser.new markdown
+      data = parser.execute
+      html = data.output
+      metadata = data.metadata
+
+      article = get_article(markdown, html, metadata)
+
+      article
+    rescue => e
+      raise "Can't read file! #{ e.message }"
+    end
+  end
+
+  private
+
+  # Private: Create or edit a Article object
+  #
+  # markdown - The content from a markdown file
+  # html     - The parsed markdown
+  # metadata - The metadata from a markdown file
+  #
+  # Returns a Article
+  def get_article(markdown, html, metadata)
+    filename = File.basename(@filename, ".*")
+
+    # Create or edit article model
+    article = Article.find_or_create_by(filename: filename)
+    article.title = metadata[:title]
+    article.slug = article.title.downcase.tr(" ", "-")
+    article.markdown = markdown
+    article.content = html
+    article.author = metadata[:author]
+    article.tags = get_tags(metadata)
+
+    article.save
+    article
+  end
+
+  # Private: Get used Tags for a Article. If a use Tag not exists,
+  # it will be created
+  #
+  # metadata - The metadata from a markdown file
+  #
+  # Returns used Tags
+  def get_tags(metadata)
+    unless metadata[:tags].nil? && metadata[:tags].empty?
+      tags = metadata[:tags]
+      metadata[:tags] = tags.split(",").map(&:strip)
+      tags = metadata[:tags].map { |title|
+        Tag.find_or_create_by(title: title)
+      }
+    end
+
+    tags
+  end
+end

--- a/spec/factories/markdown.md
+++ b/spec/factories/markdown.md
@@ -1,0 +1,8 @@
+---
+title: "Some title"
+author: "Marvin Caspar"
+tags: "test, demo"
+---
+# Demo headline
+
+Some content

--- a/spec/services/article_provider_spec.rb
+++ b/spec/services/article_provider_spec.rb
@@ -1,0 +1,48 @@
+require 'rails_helper'
+
+RSpec.describe ArticleProvider, type: :service do
+  context "with given file" do
+    let(:article_provier) { ArticleProvider.new "/var/www/html/spec/factories/markdown.md" }
+
+    it "should return a filename" do
+      article = article_provier.execute
+      expect(article.filename).to eq("markdown")
+    end
+
+    it "should return markdown" do
+      article = article_provier.execute
+      expect(article.markdown).to_not be_empty
+    end
+
+    it "should return html" do
+      article = article_provier.execute
+      expect(article.content).to eq("<h1>Demo headline</h1>\n\n<p>Some content</p>\n")
+    end
+
+    it "should return a title" do
+      article = article_provier.execute
+      expect(article.title).to eq("Some title")
+    end
+
+    it "should return an author" do
+      article = article_provier.execute
+      expect(article.author).to eq("Marvin Caspar")
+    end
+
+    it "should return tags" do
+      article = article_provier.execute
+      expect(article.tags).to eq([
+        Tag.find_by(title: "test"),
+        Tag.find_by(title: "demo")
+      ])
+    end
+  end
+
+  context "without a file" do
+    let(:article_provier) { ArticleProvider.new "" }
+
+    it "should throw an execption" do
+      expect{ article_provier.execute }.to raise_error(RuntimeError)
+    end
+  end
+end

--- a/spec/services/markdown_parser_spec.rb
+++ b/spec/services/markdown_parser_spec.rb
@@ -45,7 +45,7 @@ hello world
 
     it "should throw an execption" do
       parser = MarkdownParser.new markdown
-      expect{ parser.execute }.to raise_error
+      expect{ parser.execute }.to raise_error(RuntimeError)
     end
   end
 end


### PR DESCRIPTION
The article provider reads a markdown file and parse the content to
a article model which is not saved. The article includes tags and not existing tags
are created.